### PR TITLE
chore: dmr-web to 1.4.196-dmr

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: dmr-web
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.4.151-dmr
+  version: 1.4.196-dmr


### PR DESCRIPTION
chore: Promote dmr-web to version 1.4.196-dmr