### PR TITLE
chore: dmr-web to 1.10.280-dmr

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,4 +4,4 @@ dependencies:
   version: 10.2.0
 - name: dmr-web
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.10.269-dmr
+  version: 1.10.280-dmr


### PR DESCRIPTION
chore: Promote dmr-web to version 1.10.280-dmr